### PR TITLE
Create Project Detail view and refactor Rebass with MaterialUI

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1951,6 +1951,96 @@
         }
       }
     },
+    "@material-ui/core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.4",
+        "@material-ui/system": "^4.11.3",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+      "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.17",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+        }
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.17",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+        }
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -2544,8 +2634,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -2556,7 +2645,6 @@
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
       "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2602,6 +2690,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/rebass": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/rebass/-/rebass-4.0.8.tgz",
@@ -2636,8 +2732,7 @@
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -5005,6 +5100,15 @@
         "source-map": "^0.6.1"
       }
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
@@ -5505,6 +5609,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -7924,6 +8037,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8023,6 +8141,14 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "4.0.0",
@@ -8266,6 +8392,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-module": {
       "version": "1.0.0",
@@ -9468,6 +9599,85 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      }
+    },
+    "jss": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+      "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
+      "integrity": "sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.6.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz",
+      "integrity": "sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.6.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz",
+      "integrity": "sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.6.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz",
+      "integrity": "sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.6.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz",
+      "integrity": "sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.6.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz",
+      "integrity": "sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.6.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz",
+      "integrity": "sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.6.0"
       }
     },
     "jsx-ast-utils": {
@@ -10901,6 +11111,11 @@
       "requires": {
         "ts-pnp": "^1.1.6"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -12635,6 +12850,17 @@
       "integrity": "sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==",
       "requires": {
         "clsx": "^1.1.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {
@@ -14491,6 +14717,11 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -7,6 +7,8 @@
     "@emotion/core": "10.0.35",
     "@emotion/react": "11.4.0",
     "@emotion/styled": "11.3.0",
+    "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@rebass/forms": "4.0.6",
     "@testing-library/jest-dom": "5.12.0",
     "@testing-library/react": "11.2.6",

--- a/app/client/src/AppRouter.tsx
+++ b/app/client/src/AppRouter.tsx
@@ -21,6 +21,7 @@ import { HOME_PAGE_URL, ROUTE_PATHS } from "./constants";
 import AppRoute from "./utils/AppRoute";
 import { areQueryParamsForProfileValid } from "./utils/checkQueryParamsHelper";
 import Dashboard from "./views/Dashboard";
+import ProjectDetails from "./views/ProjectDetails";
 import { NotFound } from "./views/NotFound";
 import ProfileCreate from "./views/ProfileCreate";
 import ProfileEdit from "./views/ProfileEdit";
@@ -54,6 +55,7 @@ const AppRouter: React.FC = () => {
           component={ProfileEdit}
           checkQueryParams={areQueryParamsForProfileValid}
         />
+        <AppRoute path={ROUTE_PATHS.PROJECT_DETAILS} component={ProjectDetails} />
         <AppRoute path={ROUTE_PATHS.NOT_FOUND} component={NotFound} />
         <Redirect to={ROUTE_PATHS.DASHBOARD} />
       </Switch>

--- a/app/client/src/components/common/layout/Header.tsx
+++ b/app/client/src/components/common/layout/Header.tsx
@@ -159,7 +159,7 @@ const Header: React.FC<IHeaderProps> = (props) => {
             fontWeight={500}
             pl={[3, 0, 0]}
           >
-            Platform Services Registry
+            Reporting and Dashboard Service Improvement
           </StyledText>
         </RouterLink>
         <Nav

--- a/app/client/src/components/projectDetails/CardItem.tsx
+++ b/app/client/src/components/projectDetails/CardItem.tsx
@@ -15,7 +15,7 @@
 //
 
 import React from 'react';
-import { Box, Flex, Text } from 'rebass';
+import { Typography, Box } from '@material-ui/core';
 
 interface ICardItem {
   label?: string;
@@ -29,14 +29,20 @@ const CardItem: React.FC<ICardItem> = (props) => {
 
   return (
     <Box width={1}>
-    <Flex flexDirection="row" justifyContent="space-between">
-      <Text as="h3" fontSize={[2, 3, 3]} fontWeight={800} mb={3} ml={3}>
-      {label}
-      </Text>
-      <Text as="h3" fontSize={[2, 3, 3]} fontWeight={500} mb={3} mr={3}>
-      {content}
-      </Text>
-    </Flex>
+      <Box display="flex" flexDirection="row" justifyContent="space-between" fontWeight={800} >
+        
+        <Typography variant='h5'>
+          <Box fontWeight='fontWeightBold' mb={1} ml={3}>
+            {label}
+          </Box>
+        </Typography>
+
+        <Typography variant='h5'>
+          <Box fontWeight='fontWeightRegular' mb={1} mr={3}>
+            {content}
+          </Box>
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/app/client/src/components/projectDetails/ProjectContactCard.tsx
+++ b/app/client/src/components/projectDetails/ProjectContactCard.tsx
@@ -16,7 +16,7 @@
 
 import styled from "@emotion/styled";
 import React from 'react';
-import { Box, Flex, Text } from 'rebass';
+import { Typography, Box } from '@material-ui/core';
 import theme from '../../theme';
 import CardItem from './CardItem';
 
@@ -35,16 +35,21 @@ const ProjectContactCard: React.FC<IProjectContactCardProps> = (props) => {
 
   return (
     <Box style={{border: '1px solid black'}} m={4}>
-    <Flex alignItems="center" justifyContent="center" flexDirection="column" >
-      <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bg="#D5D5D5">
-      <Text as="h2" fontSize={[3, 4, 4]} fontWeight={800} m={2}>
-      Project Identification
-      </Text>
+      <Box display='flex' alignItems="center" justifyContent="center" flexDirection="column" >
+        
+        <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bgcolor="#D5D5D5">
+          <Typography variant="h4">
+            <Box fontWeight='fontWeightBold' m={1 / 2}>
+              Project Contacts
+            </Box>
+          </Typography>
+        </Box>
+
+        <CardItem label={'Project Sponsor'} content={sponsor} />
+        <CardItem label={'Project Manager'} content={manager} />
+        <CardItem label={'Financial Contact'} content={financialContact} />
+
       </Box>
-      <CardItem label={'Project Sponsor'} content={sponsor} />
-      <CardItem label={'Project Manager'} content={manager} />
-      <CardItem label={'Financial Contact'} content={financialContact} />
-    </Flex>
     </Box>
   );
 }

--- a/app/client/src/components/projectDetails/ProjectIDCard.tsx
+++ b/app/client/src/components/projectDetails/ProjectIDCard.tsx
@@ -16,7 +16,7 @@
 
 import styled from "@emotion/styled";
 import React from 'react';
-import { Box, Flex, Text } from 'rebass';
+import { Typography, Box } from '@material-ui/core';
 import theme from '../../theme';
 import CardItem from './CardItem';
 
@@ -42,19 +42,22 @@ const ProjectIDCard: React.FC<IProjectIDCardProps> = (props) => {
   // TODO: refactor any custom colours and theming using the theme provider
   return (
     <Box style={{border: '1px solid black'}} m={4}>
-      <Flex alignItems="center" justifyContent="center" flexDirection="column" >
-        <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bg="#D5D5D5">
-          <Text as="h2" fontSize={[3, 4, 4]} fontWeight={800} m={2}>
-          Project Identification
-          </Text>
+      <Box display="flex" alignItems="center" justifyContent="center" flexDirection="column" >
+        <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bgcolor="#D5D5D5">
+          <Typography variant='h4'>
+            <Box fontWeight='fontWeightBold' m={1 / 2}>
+              Project Identification
+            </Box>
+          </Typography>
         </Box>
+        
         <CardItem label={'Project Name'} content={name} />
         <CardItem label={'Project Description'} content={description} />
         <CardItem label={'Ministry'} content={ministry} />
         <CardItem label={'Program Name'} content={program} />
         <CardItem label={'CPS Identifier'} content={CPS} />
         <CardItem label={'Ministry Project Number'} content={ministryProjectNumber} />
-      </Flex>
+      </Box>
     </Box>
   );
 };

--- a/app/client/src/components/projectDetails/ProjectProgressCard.tsx
+++ b/app/client/src/components/projectDetails/ProjectProgressCard.tsx
@@ -16,7 +16,7 @@
 
 import styled from "@emotion/styled";
 import React from 'react';
-import { Box, Flex, Text } from 'rebass';
+import { Typography, Box } from '@material-ui/core';
 import theme from '../../theme';
 import CardItem from './CardItem';
 
@@ -35,16 +35,20 @@ const ProjectProgressCard: React.FC<IProjectProgressCardProps> = (props) => {
 
   return (
     <Box style={{border: '1px solid black'}} m={4}>
-    <Flex alignItems="center" justifyContent="center" flexDirection="column" >
-      <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bg="#D5D5D5">
-      <Text as="h2" fontSize={[3, 4, 4]} fontWeight={800} m={2}>
-      Project Identification
-      </Text>
+      <Box display='flex' alignItems="center" justifyContent="center" flexDirection="column" >
+        <Box alignItems="left" style={{borderBottom: '1px solid black'}} width={1} p={2} bgcolor="#D5D5D5">
+          <Typography variant='h4'>
+            <Box fontWeight='fontWeightBold' m={1 / 2}>
+              Project Progress
+            </Box>
+          </Typography>
+        </Box>
+
+        <CardItem label={'Project Phase'} content={phase} />
+        <CardItem label={'Estimated Date of Project Completion'} content={completionDate} />
+        <CardItem label={'Percent Complete'} content={`${percentComplete}%`} />
+        {/* TODO: a progress bar to display % complete should go here */}
       </Box>
-      <CardItem label={'Project Phase'} content={phase} />
-      <CardItem label={'Estimated Date of Project Completion'} content={completionDate} />
-      <CardItem label={'Percent Complete'} content={`${percentComplete}%`} />
-    </Flex>
     </Box>
   );
 };

--- a/app/client/src/constants.ts
+++ b/app/client/src/constants.ts
@@ -2,6 +2,7 @@ export const ROUTE_PATHS = {
   NOT_FOUND: "/page-not-found",
   LANDING: "/landing",
   DASHBOARD: "/dashboard",
+  PROJECT_DETAILS: "/project-details", // TODO: this URL should have the project ID similar to PROFILE_EDIT route
   // DASHBOARD: "/",
   PROFILE_CREATE: "/profile/create",
   PROFILE_EDIT: "/profile/:profileId/:viewName",

--- a/app/client/src/views/Dashboard.tsx
+++ b/app/client/src/views/Dashboard.tsx
@@ -23,9 +23,6 @@ import { Button } from "../components/common/UI/Button";
 import { ShadowBox } from "../components/common/UI/ShadowContainer";
 import Table from "../components/common/UI/Table";
 import ProfileCard from "../components/dashboard/ProfileCard";
-import ProjectIDCard from "../components/projectDetails/ProjectIDCard";
-import ProjectProgressCard from "../components/projectDetails/ProjectProgressCard";
-import ProjectContactCard from "../components/projectDetails/ProjectContactCard";
 import ProjectRequests from "../components/dashboard/ProjectRequests";
 import { COMPONENT_METADATA, CSV_PROFILE_ATTRIBUTES } from "../constants";
 import useCommonState from "../hooks/useCommonState";
@@ -40,23 +37,6 @@ import {
   sortProfileByDatetime,
   transformJsonToCsv,
 } from "../utils/transformDataHelper";
-
-// Test data to populate project detail views
-// I am just rendering from the dashboard for now
-const testData = {
-  'name' : 'Example Project',
-  'description' : 'Quarterly report dashboard and management system',
-  'ministry' : 'Citizen Services',
-  'program' : 'Digital Investment Office',
-  'CPS' : 'LCTXXXXXXXXX',
-  'ministryProjectNumber' : 'ITAXXXXXX',
-  'sponsor' : 'John Doe',
-  'manager' : 'Jane Doe',
-  'financialContact' : 'Jane Doe',
-  'phase' : 'Phase 1 Year 20/21',
-  'completionDate' : '05-25-2021',
-  'percentComplete' : 65
-};
 
 const Dashboard: React.FC = () => {
   const api = useRegistryApi();
@@ -268,10 +248,6 @@ const Dashboard: React.FC = () => {
           </Box>
         </div>
       )}
-      {/* TODO: move these components to their own view */}
-      <ProjectProgressCard {...testData}/>
-      <ProjectIDCard {...testData}/>
-      <ProjectContactCard {...testData}/>
     </>
   );
 };

--- a/app/client/src/views/ProjectDetails.tsx
+++ b/app/client/src/views/ProjectDetails.tsx
@@ -1,0 +1,66 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,git
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { Typography, Button, Box, Container, Tabs, Tab, AppBar } from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
+import ProjectIDCard from "../components/projectDetails/ProjectIDCard";
+import ProjectProgressCard from "../components/projectDetails/ProjectProgressCard";
+import ProjectContactCard from "../components/projectDetails/ProjectContactCard";
+import theme from "../theme";
+import { promptErrToastWithText } from "../utils/promptToastHelper";
+
+// Test data to populate project detail views
+const testData = {
+  'name' : 'Example Project',
+  'description' : 'Quarterly report dashboard and management system',
+  'ministry' : 'Citizen Services',
+  'program' : 'Digital Investment Office',
+  'CPS' : 'LCTXXXXXXXXX',
+  'ministryProjectNumber' : 'ITAXXXXXX',
+  'sponsor' : 'John Doe',
+  'manager' : 'Jane Doe',
+  'financialContact' : 'Jane Doe',
+  'phase' : 'Phase 1 Year 20/21',
+  'completionDate' : '05-25-2021',
+  'percentComplete' : 65
+};
+
+/* TODO: implement tab component to be able to switch between project details and submitted reports */
+const ProjectDetails: React.FC = () => {
+  return (
+    <Container maxWidth='lg'>
+      <Box display="flex" alignItems="center" justifyContent="space-between" flexDirection="row" m={4}>
+        {/* TODO: change this to display when the next quarterly report is due */}
+        <Typography variant='h4'>
+          Q3a Status Report Due dd-mm-yy
+        </Typography>
+        <Button variant='contained' color='primary'>
+          < EditIcon/>
+          Edit Project
+        </Button>
+      </Box>
+
+      <ProjectProgressCard {...testData}/>
+      <ProjectIDCard {...testData}/>
+      <ProjectContactCard {...testData}/>
+      
+    </Container>
+  );
+};
+
+export default ProjectDetails;


### PR DESCRIPTION
scrapping work from yesterday and starting over now that I understand routing better.

Added routing to view

note: route URL should be updated when API is integrated to have the project ID in the path. Currently using "/project-details" until API connection is established

Have basic layout using rebass. Commit before refactoring with MaterialUI

Changed header text to reflect our project

Refactored ProjectDetails view to use MaterialUI instead of Rebass

Refactored CardItem to replace rebass with MaterialUI

Refactored ProjectContactCard to use MaterialUI instead of rebass

Refactored ProjectProgressCard to use MaterialUI instead of rebass

Also fixed typo of each card having "Project Identification" titles

Refactored ProjectIDCard to use MaterialUI instead of rebass

Added MaterialUI icons  package and fixed some indentation